### PR TITLE
Implement PostgreSQL + pgvector storage layer

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ TypeScript Discord bot scaffold for monitoring a channel and indexing shared lin
 - `npm run start` - Run compiled bot from `dist/`.
 - `npm run lint` - Type check without emitting files.
 - `npm run test` - Run unit tests.
+- `npm run db:migrate` - Apply SQL migrations to the configured PostgreSQL database.
 
 ## Current status
 
@@ -43,3 +44,14 @@ This repository currently provides:
 - Initial unit tests for logger behavior
 
 Further work for link extraction, database persistence, LLM integration, and semantic search is tracked in child work items under the parent epic.
+
+## Database
+
+The storage layer uses PostgreSQL with pgvector and includes:
+
+- `migrations/001_initial_schema.sql` to create `links`, `app_checkpoints`, and indexes
+- `src/db/migrate.ts` migration runner with a `schema_migrations` table
+- `src/db/repository.ts` repository helpers for:
+  - link upsert-by-URL (duplicate handling)
+  - link lookup by URL
+  - save/load checkpoint by Discord channel

--- a/migrations/001_initial_schema.sql
+++ b/migrations/001_initial_schema.sql
@@ -1,0 +1,26 @@
+CREATE EXTENSION IF NOT EXISTS vector;
+
+CREATE TABLE IF NOT EXISTS links (
+  id BIGSERIAL PRIMARY KEY,
+  url TEXT NOT NULL UNIQUE,
+  canonical_url TEXT,
+  title TEXT,
+  summary TEXT,
+  content TEXT,
+  image_url TEXT,
+  metadata JSONB NOT NULL DEFAULT '{}'::jsonb,
+  embedding vector(1536),
+  first_seen_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  last_seen_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE TABLE IF NOT EXISTS app_checkpoints (
+  channel_id TEXT PRIMARY KEY,
+  last_processed_message_id TEXT NOT NULL,
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS links_last_seen_at_idx ON links (last_seen_at DESC);
+CREATE INDEX IF NOT EXISTS links_embedding_idx ON links USING ivfflat (embedding vector_cosine_ops);

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,10 +10,12 @@
       "dependencies": {
         "discord.js": "^14.19.3",
         "dotenv": "^16.6.1",
+        "pg": "^8.16.3",
         "zod": "^3.25.67"
       },
       "devDependencies": {
         "@types/node": "^24.5.2",
+        "@types/pg": "^8.15.5",
         "tsx": "^4.20.5",
         "typescript": "^5.9.2",
         "vitest": "^3.2.4"
@@ -1018,6 +1020,18 @@
         "undici-types": "~7.16.0"
       }
     },
+    "node_modules/@types/pg": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/@types/pg/-/pg-8.20.0.tgz",
+      "integrity": "sha512-bEPFOaMAHTEP1EzpvHTbmwR8UsFyHSKsRisLIHVMXnpNefSbGA1bD6CVy+qKjGSqmZqNqBDV2azOBo8TgkcVow==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*",
+        "pg-protocol": "*",
+        "pg-types": "^2.2.0"
+      }
+    },
     "node_modules/@types/ws": {
       "version": "8.18.1",
       "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.18.1.tgz",
@@ -1481,6 +1495,95 @@
         "node": ">= 14.16"
       }
     },
+    "node_modules/pg": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/pg/-/pg-8.20.0.tgz",
+      "integrity": "sha512-ldhMxz2r8fl/6QkXnBD3CR9/xg694oT6DZQ2s6c/RI28OjtSOpxnPrUCGOBJ46RCUxcWdx3p6kw/xnDHjKvaRA==",
+      "license": "MIT",
+      "dependencies": {
+        "pg-connection-string": "^2.12.0",
+        "pg-pool": "^3.13.0",
+        "pg-protocol": "^1.13.0",
+        "pg-types": "2.2.0",
+        "pgpass": "1.0.5"
+      },
+      "engines": {
+        "node": ">= 16.0.0"
+      },
+      "optionalDependencies": {
+        "pg-cloudflare": "^1.3.0"
+      },
+      "peerDependencies": {
+        "pg-native": ">=3.0.1"
+      },
+      "peerDependenciesMeta": {
+        "pg-native": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/pg-cloudflare": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/pg-cloudflare/-/pg-cloudflare-1.3.0.tgz",
+      "integrity": "sha512-6lswVVSztmHiRtD6I8hw4qP/nDm1EJbKMRhf3HCYaqud7frGysPv7FYJ5noZQdhQtN2xJnimfMtvQq21pdbzyQ==",
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/pg-connection-string": {
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/pg-connection-string/-/pg-connection-string-2.12.0.tgz",
+      "integrity": "sha512-U7qg+bpswf3Cs5xLzRqbXbQl85ng0mfSV/J0nnA31MCLgvEaAo7CIhmeyrmJpOr7o+zm0rXK+hNnT5l9RHkCkQ==",
+      "license": "MIT"
+    },
+    "node_modules/pg-int8": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/pg-int8/-/pg-int8-1.0.1.tgz",
+      "integrity": "sha512-WCtabS6t3c8SkpDBUlb1kjOs7l66xsGdKpIPZsg4wR+B3+u9UAum2odSsF9tnvxg80h4ZxLWMy4pRjOsFIqQpw==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "node_modules/pg-pool": {
+      "version": "3.13.0",
+      "resolved": "https://registry.npmjs.org/pg-pool/-/pg-pool-3.13.0.tgz",
+      "integrity": "sha512-gB+R+Xud1gLFuRD/QgOIgGOBE2KCQPaPwkzBBGC9oG69pHTkhQeIuejVIk3/cnDyX39av2AxomQiyPT13WKHQA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "pg": ">=8.0"
+      }
+    },
+    "node_modules/pg-protocol": {
+      "version": "1.13.0",
+      "resolved": "https://registry.npmjs.org/pg-protocol/-/pg-protocol-1.13.0.tgz",
+      "integrity": "sha512-zzdvXfS6v89r6v7OcFCHfHlyG/wvry1ALxZo4LqgUoy7W9xhBDMaqOuMiF3qEV45VqsN6rdlcehHrfDtlCPc8w==",
+      "license": "MIT"
+    },
+    "node_modules/pg-types": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/pg-types/-/pg-types-2.2.0.tgz",
+      "integrity": "sha512-qTAAlrEsl8s4OiEQY69wDvcMIdQN6wdz5ojQiOy6YRMuynxenON0O5oCpJI6lshc6scgAY8qvJ2On/p+CXY0GA==",
+      "license": "MIT",
+      "dependencies": {
+        "pg-int8": "1.0.1",
+        "postgres-array": "~2.0.0",
+        "postgres-bytea": "~1.0.0",
+        "postgres-date": "~1.0.4",
+        "postgres-interval": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/pgpass": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/pgpass/-/pgpass-1.0.5.tgz",
+      "integrity": "sha512-FdW9r/jQZhSeohs1Z3sI1yxFQNFvMcnmfuj4WBMUTxOrAyLMaTcE1aAMBiTlbMNaXvBCQuVi0R7hd8udDSP7ug==",
+      "license": "MIT",
+      "dependencies": {
+        "split2": "^4.1.0"
+      }
+    },
     "node_modules/picocolors": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
@@ -1528,6 +1631,45 @@
       },
       "engines": {
         "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/postgres-array": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/postgres-array/-/postgres-array-2.0.0.tgz",
+      "integrity": "sha512-VpZrUqU5A69eQyW2c5CA1jtLecCsN2U/bD6VilrFDWq5+5UIEVO7nazS3TEcHf1zuPYO/sqGvUvW62g86RXZuA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/postgres-bytea": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/postgres-bytea/-/postgres-bytea-1.0.1.tgz",
+      "integrity": "sha512-5+5HqXnsZPE65IJZSMkZtURARZelel2oXUEO8rH83VS/hxH5vv1uHquPg5wZs8yMAfdv971IU+kcPUczi7NVBQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/postgres-date": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/postgres-date/-/postgres-date-1.0.7.tgz",
+      "integrity": "sha512-suDmjLVQg78nMK2UZ454hAG+OAW+HQPZ6n++TNDUX+L0+uUlLywnoxJKDou51Zm+zTCjrCl0Nq6J9C5hP9vK/Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/postgres-interval": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/postgres-interval/-/postgres-interval-1.2.0.tgz",
+      "integrity": "sha512-9ZhXKM/rw350N1ovuWHbGxnGh/SNJ4cnxHiM0rxE4VN41wsg8P8zWn9hv/buK00RP4WvlOyr/RBDiptyxVbkZQ==",
+      "license": "MIT",
+      "dependencies": {
+        "xtend": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/resolve-pkg-maps": {
@@ -1600,6 +1742,15 @@
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/split2": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/split2/-/split2-4.2.0.tgz",
+      "integrity": "sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">= 10.x"
       }
     },
     "node_modules/stackback": {
@@ -1958,6 +2109,15 @@
         "utf-8-validate": {
           "optional": true
         }
+      }
+    },
+    "node_modules/xtend": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
+      "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4"
       }
     },
     "node_modules/zod": {

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
   },
   "scripts": {
     "build": "tsc -p tsconfig.json",
+    "db:migrate": "tsx src/db/migrate.ts",
     "lint": "tsc --noEmit -p tsconfig.json",
     "test": "vitest run",
     "test:watch": "vitest",
@@ -18,10 +19,12 @@
   "dependencies": {
     "discord.js": "^14.19.3",
     "dotenv": "^16.6.1",
+    "pg": "^8.16.3",
     "zod": "^3.25.67"
   },
   "devDependencies": {
     "@types/node": "^24.5.2",
+    "@types/pg": "^8.15.5",
     "tsx": "^4.20.5",
     "typescript": "^5.9.2",
     "vitest": "^3.2.4"

--- a/src/db/client.ts
+++ b/src/db/client.ts
@@ -1,0 +1,22 @@
+import { Pool } from "pg";
+
+import { config } from "../config.js";
+
+let pool: Pool | undefined;
+
+export function getDbPool(): Pool {
+  if (!pool) {
+    pool = new Pool({ connectionString: config.DATABASE_URL });
+  }
+
+  return pool;
+}
+
+export async function closeDbPool(): Promise<void> {
+  if (!pool) {
+    return;
+  }
+
+  await pool.end();
+  pool = undefined;
+}

--- a/src/db/migrate.ts
+++ b/src/db/migrate.ts
@@ -1,0 +1,50 @@
+import { readdir, readFile } from "node:fs/promises";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { getDbPool, closeDbPool } from "./client.js";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+async function runMigrations(): Promise<void> {
+  const migrationsDir = path.resolve(__dirname, "../../migrations");
+  const files = (await readdir(migrationsDir))
+    .filter((name) => name.endsWith(".sql"))
+    .sort((a, b) => a.localeCompare(b));
+
+  const pool = getDbPool();
+  const client = await pool.connect();
+
+  try {
+    await client.query("BEGIN");
+    await client.query(
+      "CREATE TABLE IF NOT EXISTS schema_migrations (filename TEXT PRIMARY KEY, applied_at TIMESTAMPTZ NOT NULL DEFAULT now())"
+    );
+
+    for (const file of files) {
+      const applied = await client.query("SELECT 1 FROM schema_migrations WHERE filename = $1", [file]);
+      if (applied.rowCount && applied.rowCount > 0) {
+        continue;
+      }
+
+      const sql = await readFile(path.join(migrationsDir, file), "utf-8");
+      await client.query(sql);
+      await client.query("INSERT INTO schema_migrations (filename) VALUES ($1)", [file]);
+      console.log(`Applied migration ${file}`);
+    }
+
+    await client.query("COMMIT");
+  } catch (error) {
+    await client.query("ROLLBACK");
+    throw error;
+  } finally {
+    client.release();
+    await closeDbPool();
+  }
+}
+
+runMigrations().catch((error) => {
+  console.error(error);
+  process.exitCode = 1;
+});

--- a/src/db/repository.ts
+++ b/src/db/repository.ts
@@ -1,0 +1,186 @@
+export interface LinkRecord {
+  url: string;
+  canonicalUrl?: string | null;
+  title?: string | null;
+  summary?: string | null;
+  content?: string | null;
+  imageUrl?: string | null;
+  metadata?: Record<string, unknown>;
+  embedding?: number[] | null;
+}
+
+export interface StoredLink {
+  id: number;
+  url: string;
+  canonicalUrl: string | null;
+  title: string | null;
+  summary: string | null;
+  content: string | null;
+  imageUrl: string | null;
+  metadata: Record<string, unknown>;
+  firstSeenAt: string;
+  lastSeenAt: string;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface Queryable {
+  query: (sql: string, params?: unknown[]) => Promise<{ rowCount: number | null; rows: unknown[] }>;
+}
+
+export class LinkRepository {
+  constructor(private readonly pool: Queryable) {}
+
+  async upsertLink(link: LinkRecord): Promise<StoredLink> {
+    const embeddingLiteral = link.embedding ? toVectorLiteral(link.embedding) : null;
+    const result = await this.pool.query(
+      `
+      INSERT INTO links (
+        url,
+        canonical_url,
+        title,
+        summary,
+        content,
+        image_url,
+        metadata,
+        embedding,
+        first_seen_at,
+        last_seen_at,
+        created_at,
+        updated_at
+      )
+      VALUES ($1, $2, $3, $4, $5, $6, $7::jsonb, $8::vector, now(), now(), now(), now())
+      ON CONFLICT (url)
+      DO UPDATE SET
+        canonical_url = EXCLUDED.canonical_url,
+        title = EXCLUDED.title,
+        summary = EXCLUDED.summary,
+        content = EXCLUDED.content,
+        image_url = EXCLUDED.image_url,
+        metadata = EXCLUDED.metadata,
+        embedding = COALESCE(EXCLUDED.embedding, links.embedding),
+        last_seen_at = now(),
+        updated_at = now()
+      RETURNING
+        id,
+        url,
+        canonical_url,
+        title,
+        summary,
+        content,
+        image_url,
+        metadata,
+        first_seen_at,
+        last_seen_at,
+        created_at,
+        updated_at
+      `,
+      [
+        link.url,
+        link.canonicalUrl ?? null,
+        link.title ?? null,
+        link.summary ?? null,
+        link.content ?? null,
+        link.imageUrl ?? null,
+        JSON.stringify(link.metadata ?? {}),
+        embeddingLiteral
+      ]
+    );
+
+    const row = result.rows[0] as StoredLinkRow;
+    return mapStoredLink(row);
+  }
+
+  async getLinkByUrl(url: string): Promise<StoredLink | null> {
+    const result = await this.pool.query(
+      `
+      SELECT
+        id,
+        url,
+        canonical_url,
+        title,
+        summary,
+        content,
+        image_url,
+        metadata,
+        first_seen_at,
+        last_seen_at,
+        created_at,
+        updated_at
+      FROM links
+      WHERE url = $1
+      `,
+      [url]
+    );
+
+    if (result.rowCount === 0) {
+      return null;
+    }
+
+    return mapStoredLink(result.rows[0] as StoredLinkRow);
+  }
+
+  async saveCheckpoint(channelId: string, lastProcessedMessageId: string): Promise<void> {
+    await this.pool.query(
+      `
+      INSERT INTO app_checkpoints (channel_id, last_processed_message_id, updated_at)
+      VALUES ($1, $2, now())
+      ON CONFLICT (channel_id)
+      DO UPDATE SET
+        last_processed_message_id = EXCLUDED.last_processed_message_id,
+        updated_at = now()
+      `,
+      [channelId, lastProcessedMessageId]
+    );
+  }
+
+  async getCheckpoint(channelId: string): Promise<string | null> {
+    const result = await this.pool.query(
+      "SELECT last_processed_message_id FROM app_checkpoints WHERE channel_id = $1",
+      [channelId]
+    );
+
+    if (!result.rowCount) {
+      return null;
+    }
+
+    const row = result.rows[0] as { last_processed_message_id: string };
+    return row.last_processed_message_id;
+  }
+}
+
+interface StoredLinkRow {
+  id: number;
+  url: string;
+  canonical_url: string | null;
+  title: string | null;
+  summary: string | null;
+  content: string | null;
+  image_url: string | null;
+  metadata: Record<string, unknown>;
+  first_seen_at: Date | string;
+  last_seen_at: Date | string;
+  created_at: Date | string;
+  updated_at: Date | string;
+}
+
+function mapStoredLink(row: StoredLinkRow): StoredLink {
+  return {
+    id: row.id,
+    url: row.url,
+    canonicalUrl: row.canonical_url,
+    title: row.title,
+    summary: row.summary,
+    content: row.content,
+    imageUrl: row.image_url,
+    metadata: row.metadata,
+    firstSeenAt: row.first_seen_at instanceof Date ? row.first_seen_at.toISOString() : String(row.first_seen_at),
+    lastSeenAt: row.last_seen_at instanceof Date ? row.last_seen_at.toISOString() : String(row.last_seen_at),
+    createdAt: row.created_at instanceof Date ? row.created_at.toISOString() : String(row.created_at),
+    updatedAt: row.updated_at instanceof Date ? row.updated_at.toISOString() : String(row.updated_at)
+  };
+}
+
+function toVectorLiteral(values: number[]): string {
+  return `[${values.join(",")}]`;
+}

--- a/tests/db.repository.test.ts
+++ b/tests/db.repository.test.ts
@@ -1,0 +1,150 @@
+import { describe, expect, it } from "vitest";
+
+import type { Queryable } from "../src/db/repository.js";
+import { LinkRepository } from "../src/db/repository.js";
+
+describe("LinkRepository", () => {
+  it("inserts new links and returns stored row", async () => {
+    const pool = createFakePool();
+    const repository = new LinkRepository(pool);
+
+    const stored = await repository.upsertLink({
+      url: "https://example.com/a",
+      title: "Example",
+      metadata: { source: "test" },
+      embedding: [0.1, 0.2]
+    });
+
+    expect(stored.id).toBe(1);
+    expect(stored.url).toBe("https://example.com/a");
+    expect(stored.title).toBe("Example");
+    expect(stored.metadata).toEqual({ source: "test" });
+  });
+
+  it("upserts duplicate links without creating a second row", async () => {
+    const pool = createFakePool();
+    const repository = new LinkRepository(pool);
+
+    await repository.upsertLink({
+      url: "https://example.com/a",
+      title: "Old title",
+      metadata: { version: 1 }
+    });
+
+    const updated = await repository.upsertLink({
+      url: "https://example.com/a",
+      title: "New title",
+      metadata: { version: 2 }
+    });
+
+    expect(updated.id).toBe(1);
+    expect(updated.title).toBe("New title");
+    expect(updated.metadata).toEqual({ version: 2 });
+
+    const lookup = await repository.getLinkByUrl("https://example.com/a");
+    expect(lookup?.id).toBe(1);
+    expect(lookup?.title).toBe("New title");
+  });
+
+  it("saves and loads per-channel checkpoints", async () => {
+    const pool = createFakePool();
+    const repository = new LinkRepository(pool);
+
+    expect(await repository.getCheckpoint("123")).toBeNull();
+
+    await repository.saveCheckpoint("123", "987");
+    expect(await repository.getCheckpoint("123")).toBe("987");
+
+    await repository.saveCheckpoint("123", "999");
+    expect(await repository.getCheckpoint("123")).toBe("999");
+  });
+});
+
+type LinkRow = {
+  id: number;
+  url: string;
+  canonical_url: string | null;
+  title: string | null;
+  summary: string | null;
+  content: string | null;
+  image_url: string | null;
+  metadata: Record<string, unknown>;
+  first_seen_at: string;
+  last_seen_at: string;
+  created_at: string;
+  updated_at: string;
+  embedding: string | null;
+};
+
+function createFakePool(): Queryable {
+  const links = new Map<string, LinkRow>();
+  const checkpoints = new Map<string, string>();
+  let id = 0;
+
+  return {
+    async query(sql: string, params: unknown[] = []) {
+      if (sql.includes("INSERT INTO links")) {
+        const url = String(params[0]);
+        const now = new Date().toISOString();
+        const existing = links.get(url);
+
+        if (existing) {
+          const updated: LinkRow = {
+            ...existing,
+            canonical_url: (params[1] as string | null) ?? null,
+            title: (params[2] as string | null) ?? null,
+            summary: (params[3] as string | null) ?? null,
+            content: (params[4] as string | null) ?? null,
+            image_url: (params[5] as string | null) ?? null,
+            metadata: JSON.parse(String(params[6])) as Record<string, unknown>,
+            embedding: (params[7] as string | null) ?? existing.embedding,
+            last_seen_at: now,
+            updated_at: now
+          };
+          links.set(url, updated);
+          return { rowCount: 1, rows: [updated] };
+        }
+
+        id += 1;
+        const inserted: LinkRow = {
+          id,
+          url,
+          canonical_url: (params[1] as string | null) ?? null,
+          title: (params[2] as string | null) ?? null,
+          summary: (params[3] as string | null) ?? null,
+          content: (params[4] as string | null) ?? null,
+          image_url: (params[5] as string | null) ?? null,
+          metadata: JSON.parse(String(params[6])) as Record<string, unknown>,
+          embedding: (params[7] as string | null) ?? null,
+          first_seen_at: now,
+          last_seen_at: now,
+          created_at: now,
+          updated_at: now
+        };
+
+        links.set(url, inserted);
+        return { rowCount: 1, rows: [inserted] };
+      }
+
+      if (sql.includes("FROM links") && sql.includes("WHERE url = $1")) {
+        const row = links.get(String(params[0]));
+        return { rowCount: row ? 1 : 0, rows: row ? [row] : [] };
+      }
+
+      if (sql.includes("INSERT INTO app_checkpoints")) {
+        checkpoints.set(String(params[0]), String(params[1]));
+        return { rowCount: 1, rows: [] };
+      }
+
+      if (sql.includes("FROM app_checkpoints")) {
+        const value = checkpoints.get(String(params[0]));
+        return {
+          rowCount: value ? 1 : 0,
+          rows: value ? [{ last_processed_message_id: value }] : []
+        };
+      }
+
+      throw new Error(`Unhandled SQL in fake pool: ${sql}`);
+    }
+  };
+}


### PR DESCRIPTION
## Summary
- Add PostgreSQL schema migration with pgvector extension, link storage, and channel checkpoint table.
- Add migration runner and database client utilities for local development.
- Add repository methods and tests for URL upsert behavior and checkpoint persistence.

## Work Item
- Implement PostgreSQL + pgvector storage layer (SB-0MN1MK6YB0K5YDI2)

## Validation
- `npm run lint`
- `npm run test`
- `npm run build`

## Manual test instructions
1. Ensure PostgreSQL is running and `DATABASE_URL` in `.env` points to it.
2. Run `npm run db:migrate`.
3. Verify tables `links`, `app_checkpoints`, and `schema_migrations` exist.
4. Run `npm run test` and confirm repository tests pass.

## Review focus
- SQL migration correctness (pgvector extension, indexes, schema choices).
- Upsert semantics for duplicate URLs and embedding preservation.
- Checkpoint save/load behavior for future startup recovery flow.