### PR TITLE
Implement semantic query detection and retrieval replies

### DIFF
--- a/src/db/repository.ts
+++ b/src/db/repository.ts
@@ -147,6 +147,33 @@ export class LinkRepository {
     const row = result.rows[0] as { last_processed_message_id: string };
     return row.last_processed_message_id;
   }
+
+  async searchSimilarLinks(embedding: number[], limit = 3): Promise<StoredLink[]> {
+    const result = await this.pool.query(
+      `
+      SELECT
+        id,
+        url,
+        canonical_url,
+        title,
+        summary,
+        content,
+        image_url,
+        metadata,
+        first_seen_at,
+        last_seen_at,
+        created_at,
+        updated_at
+      FROM links
+      WHERE embedding IS NOT NULL
+      ORDER BY embedding <=> $1::vector
+      LIMIT $2
+      `,
+      [toVectorLiteral(embedding), limit]
+    );
+
+    return result.rows.map((row) => mapStoredLink(row as StoredLinkRow));
+  }
 }
 
 interface StoredLinkRow {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,14 +1,36 @@
 import { config } from "./config.js";
+import { getDbPool } from "./db/client.js";
+import { LinkRepository } from "./db/repository.js";
 import { DiscordBot } from "./discord/client.js";
+import { OpenAiCompatibleEmbeddingProvider } from "./llm/embeddings.js";
 import { Logger } from "./logger.js";
+import { isLikelyContentQuery } from "./query/detector.js";
+import { QueryService } from "./query/service.js";
 
 const logger = new Logger(config.LOG_LEVEL);
+const repository = new LinkRepository(getDbPool());
+const queryService = new QueryService(repository, new OpenAiCompatibleEmbeddingProvider());
 
 const bot = new DiscordBot({
   token: config.DISCORD_BOT_TOKEN,
   monitoredChannelId: config.DISCORD_CHANNEL_ID,
   logger,
   onMonitoredMessage: async (message) => {
+    if (isLikelyContentQuery(message.content)) {
+      try {
+        const reply = await queryService.answerQuery(message.content);
+        if (reply) {
+          await message.reply(reply);
+        }
+      } catch (error) {
+        logger.error("Failed to answer semantic query", {
+          messageId: message.id,
+          error: error instanceof Error ? error.message : String(error)
+        });
+      }
+      return;
+    }
+
     logger.info("Received monitored channel message", {
       messageId: message.id,
       authorId: message.author.id

--- a/src/llm/embeddings.ts
+++ b/src/llm/embeddings.ts
@@ -1,0 +1,31 @@
+import { config } from "../config.js";
+
+interface EmbeddingResponse {
+  data: Array<{ embedding: number[] }>;
+}
+
+export class OpenAiCompatibleEmbeddingProvider {
+  async embed(text: string): Promise<number[]> {
+    const response = await fetch(`${config.LLM_BASE_URL}/embeddings`, {
+      method: "POST",
+      headers: {
+        "content-type": "application/json"
+      },
+      body: JSON.stringify({
+        model: config.LLM_MODEL,
+        input: text
+      })
+    });
+
+    if (!response.ok) {
+      throw new Error(`Embedding request failed: ${response.status}`);
+    }
+
+    const json = (await response.json()) as EmbeddingResponse;
+    if (!json.data?.length || !Array.isArray(json.data[0].embedding)) {
+      throw new Error("Embedding response missing embedding vector");
+    }
+
+    return json.data[0].embedding;
+  }
+}

--- a/src/query/detector.ts
+++ b/src/query/detector.ts
@@ -1,0 +1,42 @@
+const QUERY_PREFIXES = [
+  "what",
+  "which",
+  "where",
+  "when",
+  "why",
+  "how",
+  "who",
+  "is",
+  "are",
+  "can",
+  "could",
+  "do",
+  "did",
+  "does",
+  "any"
+];
+
+const LINK_SEARCH_HINTS = [
+  "link",
+  "links",
+  "article",
+  "read",
+  "shared",
+  "post",
+  "resource",
+  "topic",
+  "about"
+];
+
+export function isLikelyContentQuery(messageContent: string): boolean {
+  const trimmed = messageContent.trim().toLowerCase();
+  if (!trimmed) {
+    return false;
+  }
+
+  const hasQuestionMark = trimmed.includes("?");
+  const startsLikeQuestion = QUERY_PREFIXES.some((prefix) => trimmed.startsWith(`${prefix} `));
+  const hasSearchHint = LINK_SEARCH_HINTS.some((hint) => trimmed.includes(hint));
+
+  return hasQuestionMark || (startsLikeQuestion && hasSearchHint);
+}

--- a/src/query/service.ts
+++ b/src/query/service.ts
@@ -1,0 +1,41 @@
+import type { StoredLink } from "../db/repository.js";
+
+export interface EmbeddingProvider {
+  embed(text: string): Promise<number[]>;
+}
+
+export interface SearchableLinkStore {
+  searchSimilarLinks(embedding: number[], limit: number): Promise<StoredLink[]>;
+}
+
+export class QueryService {
+  constructor(
+    private readonly store: SearchableLinkStore,
+    private readonly embeddingProvider: EmbeddingProvider
+  ) {}
+
+  async answerQuery(messageContent: string): Promise<string | null> {
+    const query = messageContent.trim();
+    if (!query) {
+      return null;
+    }
+
+    const embedding = await this.embeddingProvider.embed(query);
+    const results = await this.store.searchSimilarLinks(embedding, 3);
+
+    if (!results.length) {
+      return "I could not find any previously shared links for that query yet.";
+    }
+
+    const lines = ["Here are the most relevant links I found:"];
+    for (const [index, result] of results.entries()) {
+      const title = result.title ?? result.url;
+      const summary = result.summary?.trim() || "No summary available.";
+      lines.push(`${index + 1}. ${title}`);
+      lines.push(`   ${result.url}`);
+      lines.push(`   ${summary}`);
+    }
+
+    return lines.join("\n");
+  }
+}

--- a/tests/db.repository.test.ts
+++ b/tests/db.repository.test.ts
@@ -58,6 +58,30 @@ describe("LinkRepository", () => {
     await repository.saveCheckpoint("123", "999");
     expect(await repository.getCheckpoint("123")).toBe("999");
   });
+
+  it("searches links by semantic distance order", async () => {
+    const pool = createFakePool();
+    const repository = new LinkRepository(pool);
+
+    await repository.upsertLink({
+      url: "https://example.com/close",
+      title: "Close",
+      summary: "Closest match",
+      embedding: [0.9, 0.1, 0]
+    });
+
+    await repository.upsertLink({
+      url: "https://example.com/far",
+      title: "Far",
+      summary: "Far match",
+      embedding: [0, 1, 0]
+    });
+
+    const results = await repository.searchSimilarLinks([1, 0, 0], 2);
+    expect(results).toHaveLength(2);
+    expect(results[0].url).toBe("https://example.com/close");
+    expect(results[1].url).toBe("https://example.com/far");
+  });
 });
 
 type LinkRow = {
@@ -144,7 +168,43 @@ function createFakePool(): Queryable {
         };
       }
 
+      if (sql.includes("ORDER BY embedding <=>")) {
+        const queryEmbedding = parseVector(String(params[0]));
+        const limit = Number(params[1]);
+
+        const withEmbeddings = Array.from(links.values())
+          .filter((row) => Boolean(row.embedding))
+          .sort((a, b) => {
+            const distA = cosineDistance(queryEmbedding, parseVector(String(a.embedding)));
+            const distB = cosineDistance(queryEmbedding, parseVector(String(b.embedding)));
+            return distA - distB;
+          })
+          .slice(0, limit);
+
+        return { rowCount: withEmbeddings.length, rows: withEmbeddings };
+      }
+
       throw new Error(`Unhandled SQL in fake pool: ${sql}`);
     }
   };
+}
+
+function parseVector(value: string): number[] {
+  return value
+    .replace("[", "")
+    .replace("]", "")
+    .split(",")
+    .filter((item) => item.length > 0)
+    .map((item) => Number(item));
+}
+
+function cosineDistance(a: number[], b: number[]): number {
+  const dot = a.reduce((sum, current, index) => sum + current * (b[index] ?? 0), 0);
+  const aNorm = Math.sqrt(a.reduce((sum, current) => sum + current * current, 0));
+  const bNorm = Math.sqrt(b.reduce((sum, current) => sum + current * current, 0));
+  if (!aNorm || !bNorm) {
+    return 1;
+  }
+
+  return 1 - dot / (aNorm * bNorm);
 }

--- a/tests/query.detector.test.ts
+++ b/tests/query.detector.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from "vitest";
+
+import { isLikelyContentQuery } from "../src/query/detector.js";
+
+describe("isLikelyContentQuery", () => {
+  it("detects explicit questions", () => {
+    expect(isLikelyContentQuery("What links do we have about pgvector?")).toBe(true);
+    expect(isLikelyContentQuery("Any article on Discord bot retries?")).toBe(true);
+  });
+
+  it("detects implicit question + search hint", () => {
+    expect(isLikelyContentQuery("how to find links about embeddings")).toBe(true);
+  });
+
+  it("ignores normal conversation", () => {
+    expect(isLikelyContentQuery("great work everyone shipping today")).toBe(false);
+    expect(isLikelyContentQuery("check this out https://example.com")).toBe(false);
+  });
+});

--- a/tests/query.service.test.ts
+++ b/tests/query.service.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from "vitest";
+
+import type { StoredLink } from "../src/db/repository.js";
+import { QueryService } from "../src/query/service.js";
+
+describe("QueryService", () => {
+  it("formats ranked semantic results", async () => {
+    const service = new QueryService(
+      {
+        searchSimilarLinks: async () => [
+          createLink("https://example.com/a", "A title", "A summary"),
+          createLink("https://example.com/b", "B title", "B summary")
+        ]
+      },
+      {
+        embed: async () => [0.1, 0.2, 0.3]
+      }
+    );
+
+    const reply = await service.answerQuery("what was shared about bots?");
+    expect(reply).toContain("Here are the most relevant links I found:");
+    expect(reply).toContain("1. A title");
+    expect(reply).toContain("2. B title");
+  });
+
+  it("returns fallback text when no matches exist", async () => {
+    const service = new QueryService(
+      {
+        searchSimilarLinks: async () => []
+      },
+      {
+        embed: async () => [0.1]
+      }
+    );
+
+    const reply = await service.answerQuery("anything on abc");
+    expect(reply).toBe("I could not find any previously shared links for that query yet.");
+  });
+});
+
+function createLink(url: string, title: string, summary: string): StoredLink {
+  return {
+    id: 1,
+    url,
+    canonicalUrl: null,
+    title,
+    summary,
+    content: null,
+    imageUrl: null,
+    metadata: {},
+    firstSeenAt: new Date().toISOString(),
+    lastSeenAt: new Date().toISOString(),
+    createdAt: new Date().toISOString(),
+    updatedAt: new Date().toISOString()
+  };
+}


### PR DESCRIPTION
## Summary
- Add automatic query detection heuristics for in-channel natural-language questions.
- Add semantic query orchestration that embeds user queries and retrieves ranked link matches.
- Wire Discord message handling to reply in-channel with ranked results and summaries.

## Work Item
- Implement semantic query detection and retrieval replies (SB-0MN1MK6YF17YCHS1)

## Validation
- `npm run lint`
- `npm run test`
- `npm run build`

## Manual test instructions
1. Ensure DB contains some link rows with populated embedding vectors.
2. Start bot with valid `.env` values.
3. In monitored channel, send a natural-language query such as "What links do we have about pgvector?".
4. Confirm bot replies with ranked links, URLs, and summaries in same channel.

## Review focus
- Query detection tradeoffs and potential false positives.
- Semantic retrieval SQL ordering and response formatting.
- Error handling path when embedding generation fails.