### PR TITLE
Build link ingestion and content extraction pipeline

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3,4 +3,5 @@ DISCORD_CHANNEL_ID=your_channel_id
 LLM_BASE_URL=http://localhost:11434/v1
 LLM_MODEL=your-model-name
 DATABASE_URL=postgres://postgres:postgres@localhost:5432/discord_links
+INGEST_FAILURE_REACTION=⚠️
 LOG_LEVEL=info

--- a/README.md
+++ b/README.md
@@ -42,6 +42,9 @@ This repository currently provides:
 - Discord client bootstrap with monitored channel filtering
 - Basic structured logger utility
 - Initial unit tests for logger behavior
+- URL extraction from Discord messages
+- Article extraction using `@extractus/article-extractor`
+- Ingestion flow with DB upsert and failure reactions
 
 Further work for link extraction, database persistence, LLM integration, and semantic search is tracked in child work items under the parent epic.
 
@@ -55,3 +58,10 @@ The storage layer uses PostgreSQL with pgvector and includes:
   - link upsert-by-URL (duplicate handling)
   - link lookup by URL
   - save/load checkpoint by Discord channel
+
+## Ingestion pipeline
+
+- URL detection uses `src/ingestion/url.ts`
+- Content extraction uses `src/ingestion/extractor.ts` (`@extractus/article-extractor`)
+- Ingestion orchestration uses `src/ingestion/service.ts`
+- On extraction/storage failure, the bot reacts to the source message with `INGEST_FAILURE_REACTION`

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "discord-link-aggregation-bot",
       "version": "0.1.0",
       "dependencies": {
+        "@extractus/article-extractor": "^8.0.8",
         "discord.js": "^14.19.3",
         "dotenv": "^16.6.1",
         "pg": "^8.16.3",
@@ -596,11 +597,42 @@
         "node": ">=18"
       }
     },
+    "node_modules/@extractus/article-extractor": {
+      "version": "8.0.20",
+      "resolved": "https://registry.npmjs.org/@extractus/article-extractor/-/article-extractor-8.0.20.tgz",
+      "integrity": "sha512-oxHLZ3X5ctLVkQfFkOLf8afvQq6aJ2VBxwQhAaV6ZypaaMJboFz8uwpCGy7QBehmQIvzgWhCwuu8j4ayJFvPcg==",
+      "license": "MIT",
+      "dependencies": {
+        "@mozilla/readability": "^0.6.0",
+        "@ndaidong/bellajs": "^12.0.1",
+        "cross-fetch": "^4.1.0",
+        "linkedom": "^0.18.12",
+        "sanitize-html": "2.17.0"
+      },
+      "engines": {
+        "node": ">= 20"
+      }
+    },
     "node_modules/@jridgewell/sourcemap-codec": {
       "version": "1.5.5",
       "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
       "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@mozilla/readability": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/@mozilla/readability/-/readability-0.6.0.tgz",
+      "integrity": "sha512-juG5VWh4qAivzTAeMzvY9xs9HY5rAcr2E4I7tiSSCokRFi7XIZCAu92ZkSTsIj1OPceCifL3cpfteP3pDT9/QQ==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@ndaidong/bellajs": {
+      "version": "12.0.1",
+      "resolved": "https://registry.npmjs.org/@ndaidong/bellajs/-/bellajs-12.0.1.tgz",
+      "integrity": "sha512-1iY42uiHz0cxNMbde7O3zVN+ZX1viOOUOBRt6ht6lkRZbSjwOnFV34Zv4URp3hGzEe6L9Byk7BOq/41H0PzAOQ==",
       "license": "MIT"
     },
     "node_modules/@rollup/rollup-android-arm-eabi": {
@@ -1176,6 +1208,12 @@
         "node": ">=12"
       }
     },
+    "node_modules/boolbase": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz",
+      "integrity": "sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww==",
+      "license": "ISC"
+    },
     "node_modules/cac": {
       "version": "6.7.14",
       "resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
@@ -1213,6 +1251,49 @@
         "node": ">= 16"
       }
     },
+    "node_modules/cross-fetch": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-4.1.0.tgz",
+      "integrity": "sha512-uKm5PU+MHTootlWEY+mZ4vvXoCn4fLQxT9dSc1sXVMSFkINTJVN8cAQROpwcKm8bJ/c7rgZVIBWzH5T78sNZZw==",
+      "license": "MIT",
+      "dependencies": {
+        "node-fetch": "^2.7.0"
+      }
+    },
+    "node_modules/css-select": {
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/css-select/-/css-select-5.2.2.tgz",
+      "integrity": "sha512-TizTzUddG/xYLA3NXodFM0fSbNizXjOKhqiQQwvhlspadZokn1KDy0NZFS0wuEubIYAV5/c1/lAr0TaaFXEXzw==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "boolbase": "^1.0.0",
+        "css-what": "^6.1.0",
+        "domhandler": "^5.0.2",
+        "domutils": "^3.0.1",
+        "nth-check": "^2.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/fb55"
+      }
+    },
+    "node_modules/css-what": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/css-what/-/css-what-6.2.2.tgz",
+      "integrity": "sha512-u/O3vwbptzhMs3L1fQE82ZSLHQQfto5gyZzwteVIEyeaY5Fc7R4dapF/BvRoSYFeqfBk4m0V1Vafq5Pjv25wvA==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">= 6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/fb55"
+      }
+    },
+    "node_modules/cssom": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/cssom/-/cssom-0.5.0.tgz",
+      "integrity": "sha512-iKuQcq+NdHqlAcwUY0o/HL69XQrUaQdMjmStJ8JFmUaiiQErlhrmuigkg/CU4E2J0IyUKUrMAgl36TvN67MqTw==",
+      "license": "MIT"
+    },
     "node_modules/debug": {
       "version": "4.4.3",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
@@ -1239,6 +1320,15 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/deepmerge": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.3.1.tgz",
+      "integrity": "sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/discord-api-types": {
@@ -1277,6 +1367,61 @@
         "url": "https://github.com/discordjs/discord.js?sponsor"
       }
     },
+    "node_modules/dom-serializer": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-2.0.0.tgz",
+      "integrity": "sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==",
+      "license": "MIT",
+      "dependencies": {
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.2",
+        "entities": "^4.2.0"
+      },
+      "funding": {
+        "url": "https://github.com/cheeriojs/dom-serializer?sponsor=1"
+      }
+    },
+    "node_modules/domelementtype": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.3.0.tgz",
+      "integrity": "sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fb55"
+        }
+      ],
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/domhandler": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-5.0.3.tgz",
+      "integrity": "sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "domelementtype": "^2.3.0"
+      },
+      "engines": {
+        "node": ">= 4"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/domhandler?sponsor=1"
+      }
+    },
+    "node_modules/domutils": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/domutils/-/domutils-3.2.2.tgz",
+      "integrity": "sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "dom-serializer": "^2.0.0",
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.3"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/domutils?sponsor=1"
+      }
+    },
     "node_modules/dotenv": {
       "version": "16.6.1",
       "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.6.1.tgz",
@@ -1287,6 +1432,18 @@
       },
       "funding": {
         "url": "https://dotenvx.com"
+      }
+    },
+    "node_modules/entities": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
+      "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
       }
     },
     "node_modules/es-module-lexer": {
@@ -1336,6 +1493,18 @@
         "@esbuild/win32-arm64": "0.27.4",
         "@esbuild/win32-ia32": "0.27.4",
         "@esbuild/win32-x64": "0.27.4"
+      }
+    },
+    "node_modules/escape-string-regexp": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+      "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/estree-walker": {
@@ -1410,12 +1579,82 @@
         "url": "https://github.com/privatenumber/get-tsconfig?sponsor=1"
       }
     },
+    "node_modules/html-escaper": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-3.0.3.tgz",
+      "integrity": "sha512-RuMffC89BOWQoY0WKGpIhn5gX3iI54O6nRA0yC124NYVtzjmFWBIiFd8M0x+ZdX0P9R4lADg1mgP8C7PxGOWuQ==",
+      "license": "MIT"
+    },
+    "node_modules/htmlparser2": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-10.1.0.tgz",
+      "integrity": "sha512-VTZkM9GWRAtEpveh7MSF6SjjrpNVNNVJfFup7xTY3UpFtm67foy9HDVXneLtFVt4pMz5kZtgNcvCniNFb1hlEQ==",
+      "funding": [
+        "https://github.com/fb55/htmlparser2?sponsor=1",
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fb55"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.3",
+        "domutils": "^3.2.2",
+        "entities": "^7.0.1"
+      }
+    },
+    "node_modules/htmlparser2/node_modules/entities": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-7.0.1.tgz",
+      "integrity": "sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/is-plain-object": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-5.0.0.tgz",
+      "integrity": "sha512-VRSzKkbMm5jMDoKLbltAkFQ5Qr7VDiTFGXxYFXXowVj387GeGNOCsOH6Msy00SGZ3Fp84b1Naa1psqgcCIEP5Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/js-tokens": {
       "version": "9.0.1",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-9.0.1.tgz",
       "integrity": "sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/linkedom": {
+      "version": "0.18.12",
+      "resolved": "https://registry.npmjs.org/linkedom/-/linkedom-0.18.12.tgz",
+      "integrity": "sha512-jalJsOwIKuQJSeTvsgzPe9iJzyfVaEJiEXl+25EkKevsULHvMJzpNqwvj1jOESWdmgKDiXObyjOYwlUqG7wo1Q==",
+      "license": "ISC",
+      "dependencies": {
+        "css-select": "^5.1.0",
+        "cssom": "^0.5.0",
+        "html-escaper": "^3.0.3",
+        "htmlparser2": "^10.0.0",
+        "uhyphen": "^0.2.0"
+      },
+      "engines": {
+        "node": ">=16"
+      },
+      "peerDependencies": {
+        "canvas": ">= 2"
+      },
+      "peerDependenciesMeta": {
+        "canvas": {
+          "optional": true
+        }
+      }
     },
     "node_modules/lodash": {
       "version": "4.17.23",
@@ -1463,7 +1702,6 @@
       "version": "3.3.11",
       "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
       "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -1477,6 +1715,44 @@
       "engines": {
         "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
       }
+    },
+    "node_modules/node-fetch": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
+      "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-url": "^5.0.0"
+      },
+      "engines": {
+        "node": "4.x || >=6.0.0"
+      },
+      "peerDependencies": {
+        "encoding": "^0.1.0"
+      },
+      "peerDependenciesMeta": {
+        "encoding": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/nth-check": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/nth-check/-/nth-check-2.1.1.tgz",
+      "integrity": "sha512-lqjrjmaOoAnWfMmBPL+XNnynZh2+swxiX3WUE0s4yEHI6m+AwrK2UZOimIRl3X/4QctVqS8AiZjFqyOGrMXb/w==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "boolbase": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/nth-check?sponsor=1"
+      }
+    },
+    "node_modules/parse-srcset": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/parse-srcset/-/parse-srcset-1.0.2.tgz",
+      "integrity": "sha512-/2qh0lav6CmI15FzA3i/2Bzk2zCgQhGMkvhOhKNcBVQ1ldgpbfiNTVslmooUmWJcADi1f1kIeynbDRVzNlfR6Q==",
+      "license": "MIT"
     },
     "node_modules/pathe": {
       "version": "2.0.3",
@@ -1588,7 +1864,6 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
       "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/picomatch": {
@@ -1608,7 +1883,6 @@
       "version": "8.5.8",
       "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.8.tgz",
       "integrity": "sha512-OW/rX8O/jXnm82Ey1k44pObPtdblfiuWnrd8X7GJ7emImCOstunGbXUpp7HdBrFQX6rJzn3sPT397Wp5aCwCHg==",
-      "dev": true,
       "funding": [
         {
           "type": "opencollective",
@@ -1727,6 +2001,39 @@
         "fsevents": "~2.3.2"
       }
     },
+    "node_modules/sanitize-html": {
+      "version": "2.17.0",
+      "resolved": "https://registry.npmjs.org/sanitize-html/-/sanitize-html-2.17.0.tgz",
+      "integrity": "sha512-dLAADUSS8rBwhaevT12yCezvioCA+bmUTPH/u57xKPT8d++voeYE6HeluA/bPbQ15TwDBG2ii+QZIEmYx8VdxA==",
+      "license": "MIT",
+      "dependencies": {
+        "deepmerge": "^4.2.2",
+        "escape-string-regexp": "^4.0.0",
+        "htmlparser2": "^8.0.0",
+        "is-plain-object": "^5.0.0",
+        "parse-srcset": "^1.0.2",
+        "postcss": "^8.3.11"
+      }
+    },
+    "node_modules/sanitize-html/node_modules/htmlparser2": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-8.0.2.tgz",
+      "integrity": "sha512-GYdjWKDkbRLkZ5geuHs5NY1puJ+PXwP7+fHPRz06Eirsb9ugf6d8kkXav6ADhcODhFFPMIXyxkxSuMf3D6NCFA==",
+      "funding": [
+        "https://github.com/fb55/htmlparser2?sponsor=1",
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fb55"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.3",
+        "domutils": "^3.0.1",
+        "entities": "^4.4.0"
+      }
+    },
     "node_modules/siginfo": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
@@ -1738,7 +2045,6 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
       "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
-      "dev": true,
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.10.0"
@@ -1841,6 +2147,12 @@
         "node": ">=14.0.0"
       }
     },
+    "node_modules/tr46": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
+      "license": "MIT"
+    },
     "node_modules/ts-mixer": {
       "version": "6.0.4",
       "resolved": "https://registry.npmjs.org/ts-mixer/-/ts-mixer-6.0.4.tgz",
@@ -1886,6 +2198,12 @@
       "engines": {
         "node": ">=14.17"
       }
+    },
+    "node_modules/uhyphen": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/uhyphen/-/uhyphen-0.2.0.tgz",
+      "integrity": "sha512-qz3o9CHXmJJPGBdqzab7qAYuW8kQGKNEuoHFYrBwV6hWIMcpAmxDLXojcHfFr9US1Pe6zUswEIJIbLI610fuqA==",
+      "license": "ISC"
     },
     "node_modules/undici": {
       "version": "6.21.3",
@@ -2071,6 +2389,22 @@
         "jsdom": {
           "optional": true
         }
+      }
+    },
+    "node_modules/webidl-conversions": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/whatwg-url": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+      "license": "MIT",
+      "dependencies": {
+        "tr46": "~0.0.3",
+        "webidl-conversions": "^3.0.0"
       }
     },
     "node_modules/why-is-node-running": {

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "start:dev": "tsx watch src/index.ts"
   },
   "dependencies": {
+    "@extractus/article-extractor": "^8.0.8",
     "discord.js": "^14.19.3",
     "dotenv": "^16.6.1",
     "pg": "^8.16.3",

--- a/src/config.ts
+++ b/src/config.ts
@@ -9,6 +9,7 @@ const configSchema = z.object({
   LLM_BASE_URL: z.string().url().default("http://localhost:11434/v1"),
   LLM_MODEL: z.string().min(1).default("gpt-4o-mini"),
   DATABASE_URL: z.string().min(1, "DATABASE_URL is required"),
+  INGEST_FAILURE_REACTION: z.string().min(1).default("⚠️"),
   LOG_LEVEL: z.enum(["debug", "info", "warn", "error"]).default("info")
 });
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,6 +2,8 @@ import { config } from "./config.js";
 import { getDbPool } from "./db/client.js";
 import { LinkRepository } from "./db/repository.js";
 import { DiscordBot } from "./discord/client.js";
+import { ArticleExtractorContentExtractor } from "./ingestion/extractor.js";
+import { IngestionService } from "./ingestion/service.js";
 import { OpenAiCompatibleEmbeddingProvider } from "./llm/embeddings.js";
 import { Logger } from "./logger.js";
 import { isLikelyContentQuery } from "./query/detector.js";
@@ -10,6 +12,12 @@ import { QueryService } from "./query/service.js";
 const logger = new Logger(config.LOG_LEVEL);
 const repository = new LinkRepository(getDbPool());
 const queryService = new QueryService(repository, new OpenAiCompatibleEmbeddingProvider());
+const ingestionService = new IngestionService({
+  repository,
+  extractor: new ArticleExtractorContentExtractor(),
+  logger,
+  failureReaction: config.INGEST_FAILURE_REACTION
+});
 
 const bot = new DiscordBot({
   token: config.DISCORD_BOT_TOKEN,
@@ -35,6 +43,8 @@ const bot = new DiscordBot({
       messageId: message.id,
       authorId: message.author.id
     });
+
+    await ingestionService.ingestMessage(message);
   }
 });
 

--- a/src/ingestion/extractor.ts
+++ b/src/ingestion/extractor.ts
@@ -1,0 +1,37 @@
+import { extract } from "@extractus/article-extractor";
+
+export interface ExtractedContent {
+  url: string;
+  title: string | null;
+  content: string | null;
+  imageUrl: string | null;
+  metadata: Record<string, unknown>;
+}
+
+export interface ContentExtractor {
+  extract(url: string): Promise<ExtractedContent | null>;
+}
+
+export class ArticleExtractorContentExtractor implements ContentExtractor {
+  async extract(url: string): Promise<ExtractedContent | null> {
+    const article = await extract(url);
+    if (!article) {
+      return null;
+    }
+
+    const image = article.image ?? null;
+
+    return {
+      url,
+      title: article.title ?? null,
+      content: article.content ?? article.description ?? null,
+      imageUrl: image,
+      metadata: {
+        source: "article-extractor",
+        published: article.published ?? null,
+        author: article.author ?? null,
+        description: article.description ?? null
+      }
+    };
+  }
+}

--- a/src/ingestion/service.ts
+++ b/src/ingestion/service.ts
@@ -1,0 +1,63 @@
+import type { Message } from "discord.js";
+
+import type { LinkRecord } from "../db/repository.js";
+import type { Logger } from "../logger.js";
+import { extractUrls } from "./url.js";
+import type { ContentExtractor } from "./extractor.js";
+
+export interface LinkStore {
+  upsertLink(link: LinkRecord): Promise<unknown>;
+}
+
+export interface IngestionServiceOptions {
+  repository: LinkStore;
+  extractor: ContentExtractor;
+  logger: Logger;
+  failureReaction: string;
+}
+
+export class IngestionService {
+  constructor(private readonly options: IngestionServiceOptions) {}
+
+  async ingestMessage(message: Message): Promise<void> {
+    const urls = extractUrls(message.content);
+    if (!urls.length) {
+      return;
+    }
+
+    for (const url of urls) {
+      try {
+        const extracted = await this.options.extractor.extract(url);
+        if (!extracted) {
+          throw new Error("No extractable article content returned");
+        }
+
+        await this.options.repository.upsertLink({
+          url,
+          title: extracted.title,
+          content: extracted.content,
+          imageUrl: extracted.imageUrl,
+          metadata: {
+            ...extracted.metadata,
+            discordMessageId: message.id,
+            discordChannelId: message.channelId,
+            discordAuthorId: message.author.id
+          }
+        });
+
+        this.options.logger.info("Ingested URL from message", {
+          url,
+          messageId: message.id
+        });
+      } catch (error) {
+        this.options.logger.warn("Failed to ingest URL", {
+          url,
+          messageId: message.id,
+          error: error instanceof Error ? error.message : String(error)
+        });
+
+        await message.react(this.options.failureReaction);
+      }
+    }
+  }
+}

--- a/src/ingestion/url.ts
+++ b/src/ingestion/url.ts
@@ -1,0 +1,7 @@
+const URL_REGEX = /https?:\/\/[^\s<>()]+/gi;
+
+export function extractUrls(text: string): string[] {
+  const matches = text.match(URL_REGEX) ?? [];
+  const normalized = matches.map((raw) => raw.replace(/[),.;!?]+$/g, ""));
+  return Array.from(new Set(normalized));
+}

--- a/tests/ingestion.service.test.ts
+++ b/tests/ingestion.service.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it, vi } from "vitest";
+
+import type { LinkRecord } from "../src/db/repository.js";
+import { IngestionService } from "../src/ingestion/service.js";
+import { Logger } from "../src/logger.js";
+
+interface MessageStub {
+  id: string;
+  content: string;
+  channelId: string;
+  author: { id: string };
+  react: (emoji: string) => Promise<void>;
+}
+
+describe("IngestionService", () => {
+  it("extracts and stores URLs from messages", async () => {
+    const upsertLink = vi.fn<(_link: LinkRecord) => Promise<void>>().mockResolvedValue(undefined);
+    const service = new IngestionService({
+      repository: { upsertLink },
+      extractor: {
+        extract: async (url: string) => ({
+          url,
+          title: "Extracted title",
+          content: "Extracted content",
+          imageUrl: "https://img.example/1.png",
+          metadata: { source: "test" }
+        })
+      },
+      logger: new Logger("error"),
+      failureReaction: "⚠️"
+    });
+
+    const react = vi.fn().mockResolvedValue(undefined);
+    const message: MessageStub = {
+      id: "m1",
+      content: "check https://example.com/post",
+      channelId: "c1",
+      author: { id: "u1" },
+      react
+    };
+
+    await service.ingestMessage(message as never);
+
+    expect(upsertLink).toHaveBeenCalledTimes(1);
+    expect(react).not.toHaveBeenCalled();
+  });
+
+  it("reacts on extraction failure", async () => {
+    const upsertLink = vi.fn<(_link: LinkRecord) => Promise<void>>().mockResolvedValue(undefined);
+    const service = new IngestionService({
+      repository: { upsertLink },
+      extractor: {
+        extract: async () => {
+          throw new Error("boom");
+        }
+      },
+      logger: new Logger("error"),
+      failureReaction: "⚠️"
+    });
+
+    const react = vi.fn().mockResolvedValue(undefined);
+    const message: MessageStub = {
+      id: "m2",
+      content: "read https://example.com/failure",
+      channelId: "c1",
+      author: { id: "u1" },
+      react
+    };
+
+    await service.ingestMessage(message as never);
+
+    expect(react).toHaveBeenCalledWith("⚠️");
+  });
+});

--- a/tests/ingestion.url.test.ts
+++ b/tests/ingestion.url.test.ts
@@ -1,0 +1,15 @@
+import { describe, expect, it } from "vitest";
+
+import { extractUrls } from "../src/ingestion/url.js";
+
+describe("extractUrls", () => {
+  it("extracts unique URLs from message text", () => {
+    const urls = extractUrls("Read https://a.example/x and https://b.example/y and https://a.example/x");
+    expect(urls).toEqual(["https://a.example/x", "https://b.example/y"]);
+  });
+
+  it("strips trailing punctuation", () => {
+    const urls = extractUrls("Check https://a.example/x, then https://b.example/y!");
+    expect(urls).toEqual(["https://a.example/x", "https://b.example/y"]);
+  });
+});


### PR DESCRIPTION
## Summary
- Detect URLs in monitored Discord messages and normalize unique links.
- Extract article content and representative image metadata via `@extractus/article-extractor`.
- Persist extracted records through repository upsert and add failure reactions on processing errors.

## Work Item
- Build link ingestion and content extraction pipeline (SB-0MN1MK6YG1L59RGS)

## Validation
- `npm run lint`
- `npm run test`
- `npm run build`

## Manual test instructions
1. Start PostgreSQL and ensure migrations are applied (`npm run db:migrate`).
2. Start bot (`npm run start:dev`) with valid `.env` values.
3. Post a message in monitored channel containing one or more URLs.
4. Confirm URLs are persisted in `links` table with title/content/image metadata where available.
5. Force a failure (bad URL or extractor failure) and confirm bot reacts with `INGEST_FAILURE_REACTION`.

## Review focus
- URL extraction and normalization edge cases.
- Error handling and reaction behavior on processing failures.
- Metadata mapping and stored fields for later summary/embedding stages.